### PR TITLE
Add Course routes with pagination, filtering, and full CRUD

### DIFF
--- a/server/Pipfile
+++ b/server/Pipfile
@@ -15,6 +15,7 @@ flask-migrate = "*"
 sqlalchemy-serializer = "*"
 flask-bcrypt = "*"
 faker = "*"
+flask-restful = "*"
 
 [dev-packages]
 black = "*"

--- a/server/Pipfile.lock
+++ b/server/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4f9b31d0e341649104d760e20d767f84b78d48776777b15b0db852d772a8aae6"
+            "sha256": "4d07fee8ee7bd4636c85acec988872a83485e5f689b1e016683a1cd89a5dd667"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,13 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.16.5"
+        },
+        "aniso8601": {
+            "hashes": [
+                "sha256:25488f8663dd1528ae1f54f94ac1ea51ae25b4d531539b8bc707fed184d16845",
+                "sha256:eb19717fd4e0db6de1aab06f12450ab92144246b257423fe020af5748c0cb89e"
+            ],
+            "version": "==10.0.1"
         },
         "bcrypt": {
             "hashes": [
@@ -91,11 +98,11 @@
         },
         "click": {
             "hashes": [
-                "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
-                "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
+                "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc",
+                "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==8.2.1"
+            "version": "==8.3.0"
         },
         "faker": {
             "hashes": [
@@ -106,14 +113,14 @@
             "markers": "python_version >= '3.9'",
             "version": "==37.8.0"
         },
-        "flask-bcrypt": {
+        "flask": {
             "hashes": [
-                "sha256:062fd991dc9118d05ac0583675507b9fe4670e44416c97e0e6819d03d01f808a",
-                "sha256:f07b66b811417ea64eb188ae6455b0b708a793d966e1a80ceec4a23bc42a4369"
+                "sha256:bf656c15c80190ed628ad08cdfd3aaa35beb087855e2f494910aa3774cc4fd87",
+                "sha256:ca1d8112ec8a6158cc29ea4858963350011b5c846a414cdb7a954aa9e967d03c"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==3.0.0"
+            "markers": "python_version >= '3.9'",
+            "version": "==3.1.2"
         },
         "flask-bcrypt": {
             "hashes": [
@@ -131,15 +138,6 @@
             "index": "pypi",
             "markers": "python_version >= '3.9' and python_version < '4.0'",
             "version": "==6.0.1"
-        },
-        "flask-jwt-extended": {
-            "hashes": [
-                "sha256:52f35bf0985354d7fb7b876e2eb0e0b141aaff865a22ff6cc33d9a18aa987978",
-                "sha256:8085d6757505b6f3291a2638c84d207e8f0ad0de662d1f46aa2f77e658a0c976"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.9' and python_version < '4'",
-            "version": "==4.7.1"
         },
         "flask-migrate": {
             "hashes": [
@@ -224,7 +222,7 @@
                 "sha256:f10fd42b5ee276335863712fa3da6608e93f70629c631bf77145021600abc23c",
                 "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968"
             ],
-            "markers": "platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))",
+            "markers": "python_version < '3.14' and platform_machine == 'aarch64' or (platform_machine == 'ppc64le' or (platform_machine == 'x86_64' or (platform_machine == 'amd64' or (platform_machine == 'AMD64' or (platform_machine == 'win32' or platform_machine == 'WIN32')))))",
             "version": "==3.2.4"
         },
         "gunicorn": {
@@ -539,40 +537,40 @@
     "develop": {
         "black": {
             "hashes": [
-                "sha256:030b9759066a4ee5e5aca28c3c77f9c64789cdd4de8ac1df642c40b708be6171",
-                "sha256:055e59b198df7ac0b7efca5ad7ff2516bca343276c466be72eb04a3bcc1f82d7",
-                "sha256:0e519ecf93120f34243e6b0054db49c00a35f84f195d5bce7e9f5cfc578fc2da",
-                "sha256:172b1dbff09f86ce6f4eb8edf9dede08b1fce58ba194c87d7a4f1a5aa2f5b3c2",
-                "sha256:1e2978f6df243b155ef5fa7e558a43037c3079093ed5d10fd84c43900f2d8ecc",
-                "sha256:33496d5cd1222ad73391352b4ae8da15253c5de89b93a80b3e2c8d9a19ec2666",
-                "sha256:3b48735872ec535027d979e8dcb20bf4f70b5ac75a8ea99f127c106a7d7aba9f",
-                "sha256:4b60580e829091e6f9238c848ea6750efed72140b91b048770b64e74fe04908b",
-                "sha256:759e7ec1e050a15f89b770cefbf91ebee8917aac5c20483bc2d80a6c3a04df32",
-                "sha256:8f0b18a02996a836cc9c9c78e5babec10930862827b1b724ddfe98ccf2f2fe4f",
-                "sha256:95e8176dae143ba9097f351d174fdaf0ccd29efb414b362ae3fd72bf0f710717",
-                "sha256:96c1c7cd856bba8e20094e36e0f948718dc688dba4a9d78c3adde52b9e6c2299",
-                "sha256:a1ee0a0c330f7b5130ce0caed9936a904793576ef4d2b98c40835d6a65afa6a0",
-                "sha256:a22f402b410566e2d1c950708c77ebf5ebd5d0d88a6a2e87c86d9fb48afa0d18",
-                "sha256:a39337598244de4bae26475f77dda852ea00a93bd4c728e09eacd827ec929df0",
-                "sha256:afebb7098bfbc70037a053b91ae8437c3857482d3a690fefc03e9ff7aa9a5fd3",
-                "sha256:bacabb307dca5ebaf9c118d2d2f6903da0d62c9faa82bd21a33eecc319559355",
-                "sha256:bce2e264d59c91e52d8000d507eb20a9aca4a778731a08cfff7e5ac4a4bb7096",
-                "sha256:d9e6827d563a2c820772b32ce8a42828dc6790f095f441beef18f96aa6f8294e",
-                "sha256:db8ea9917d6f8fc62abd90d944920d95e73c83a5ee3383493e35d271aca872e9",
-                "sha256:ea0213189960bda9cf99be5b8c8ce66bb054af5e9e861249cd23471bd7b0b3ba",
-                "sha256:f3df5f1bf91d36002b0a75389ca8663510cf0531cca8aa5c1ef695b46d98655f"
+                "sha256:0172a012f725b792c358d57fe7b6b6e8e67375dd157f64fa7a3097b3ed3e2175",
+                "sha256:0474bca9a0dd1b51791fcc507a4e02078a1c63f6d4e4ae5544b9848c7adfb619",
+                "sha256:154b06d618233fe468236ba1f0e40823d4eb08b26f5e9261526fde34916b9140",
+                "sha256:1b9dc70c21ef8b43248f1d86aedd2aaf75ae110b958a7909ad8463c4aa0880b0",
+                "sha256:2ab0ce111ef026790e9b13bd216fa7bc48edd934ffc4cbf78808b235793cbc92",
+                "sha256:3bec74ee60f8dfef564b573a96b8930f7b6a538e846123d5ad77ba14a8d7a64f",
+                "sha256:456386fe87bad41b806d53c062e2974615825c7a52159cde7ccaeb0695fa28fa",
+                "sha256:474b34c1342cdc157d307b56c4c65bce916480c4a8f6551fdc6bf9b486a7c4ae",
+                "sha256:77e7060a00c5ec4b3367c55f39cf9b06e68965a4f2e61cecacd6d0d9b7ec945a",
+                "sha256:846d58e3ce7879ec1ffe816bb9df6d006cd9590515ed5d17db14e17666b2b357",
+                "sha256:8e46eecf65a095fa62e53245ae2795c90bdecabd53b50c448d0a8bcd0d2e74c4",
+                "sha256:9101ee58ddc2442199a25cb648d46ba22cd580b00ca4b44234a324e3ec7a0f7e",
+                "sha256:a16b14a44c1af60a210d8da28e108e13e75a284bf21a9afa6b4571f96ab8bb9d",
+                "sha256:aaf319612536d502fdd0e88ce52d8f1352b2c0a955cc2798f79eeca9d3af0608",
+                "sha256:b756fc75871cb1bcac5499552d771822fd9db5a2bb8db2a7247936ca48f39831",
+                "sha256:c0372a93e16b3954208417bfe448e09b0de5cc721d521866cd9e0acac3c04a1f",
+                "sha256:ce41ed2614b706fd55fd0b4a6909d06b5bab344ffbfadc6ef34ae50adba3d4f7",
+                "sha256:d119957b37cc641596063cd7db2656c5be3752ac17877017b2ffcdb9dfc4d2b1",
+                "sha256:e3c1f4cd5e93842774d9ee4ef6cd8d17790e65f44f7cdbaab5f2cf8ccf22a823",
+                "sha256:e593466de7b998374ea2585a471ba90553283fb9beefcfa430d84a2651ed5933",
+                "sha256:ef69351df3c84485a8beb6f7b8f9721e2009e20ef80a8d619e2d1788b7816d47",
+                "sha256:f96b6726d690c96c60ba682955199f8c39abc1ae0c3a494a9c62c0184049a713"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.9'",
-            "version": "==25.1.0"
+            "version": "==25.9.0"
         },
         "click": {
             "hashes": [
-                "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202",
-                "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b"
+                "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc",
+                "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4"
             ],
             "markers": "python_version >= '3.10'",
-            "version": "==8.2.1"
+            "version": "==8.3.0"
         },
         "coverage": {
             "extras": [
@@ -778,6 +776,14 @@
             "index": "pypi",
             "markers": "python_version >= '3.7'",
             "version": "==4.1.0"
+        },
+        "pytokens": {
+            "hashes": [
+                "sha256:c9a4bfa0be1d26aebce03e6884ba454e842f186a59ea43a6d3b25af58223c044",
+                "sha256:db7b72284e480e69fb085d9f251f66b3d2df8b7166059261258ff35f50fb711b"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.1.10"
         }
     }
 }

--- a/server/app/__init__.py
+++ b/server/app/__init__.py
@@ -85,5 +85,7 @@ def create_app(config_name=None):
         cors.init_app(app, origins=["*"])
     else:
         cors.init_app(app, origins=os.getenv("CORS_ORIGINS", "*").split(","))
-
+    # Register blueprints
+    from .routes import api_bp
+    app.register_blueprint(api_bp) 
     return app

--- a/server/app/extensions.py
+++ b/server/app/extensions.py
@@ -1,7 +1,27 @@
 from flask_cors import CORS
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
+from flask import request, jsonify
 
 db = SQLAlchemy()
 migrate = Migrate()
 cors = CORS()
+
+def paginate(query, serializer=lambda x: x.to_dict(), default_per_page=10):
+    """
+    Reusable pagination for list endpoints.
+    - query: SQLAlchemy query (e.g., User.query)
+    - serializer: function to convert objects to dicts
+    - default_per_page: fallback if not provided in query params
+    """
+    page = request.args.get("page", 1, type=int)
+    per_page = request.args.get("per_page", default_per_page, type=int)
+
+    items = query.paginate(page=page, per_page=per_page, error_out=False)
+
+    return jsonify({
+        "items": [serializer(item) for item in items.items],
+        "total": items.total,
+        "page": items.page,
+        "pages": items.pages
+    })

--- a/server/app/routes/__init__.py
+++ b/server/app/routes/__init__.py
@@ -1,0 +1,10 @@
+from flask_restful import Api
+from flask import Blueprint
+from .course import CourseListResource, CourseResource
+
+api_bp = Blueprint("api", __name__, url_prefix="/api")
+api = Api(api_bp)
+
+# Course endpoints
+api.add_resource(CourseListResource, "/courses")
+api.add_resource(CourseResource, "/courses/<int:course_id>")

--- a/server/app/routes/courses.py
+++ b/server/app/routes/courses.py
@@ -1,0 +1,148 @@
+from flask import request
+from flask_restful import Resource
+from app.models import Course
+from app.extensions import db, paginate
+
+
+class CourseListResource(Resource):
+    def get(self):
+        """
+        GET /courses?page=1&per_page=10&school_id=2&educator_id=7&search=AI
+
+        Returns a paginated list of courses, ordered by creation date.
+        Supports filtering:
+        - school_id: only courses from a specific school
+        - educator_id: only courses created by a specific educator
+        - search: keyword search in title and description (case-insensitive)
+        """
+        query = Course.query
+
+        # Filter: school
+        school_id = request.args.get("school_id", type=int)
+        if school_id:
+            query = query.filter_by(school_id=school_id)
+
+        # Filter: educator
+        educator_id = request.args.get("educator_id", type=int)
+        if educator_id:
+            query = query.filter_by(educator_id=educator_id)
+
+        # Search: title + description
+        search = request.args.get("search", type=str)
+        if search:
+            term = f"%{search.strip()}%"
+            query = query.filter(
+                (Course.title.ilike(term)) |
+                (Course.description.ilike(term))
+            )
+
+        # Always return newest first
+        query = query.order_by(Course.created_at.desc())
+        return paginate(query)
+
+    def post(self):
+        """
+        POST /courses
+        Create a new course.
+
+        Required fields: title, educator_id, school_id
+        Optional: description
+        """
+        data = request.get_json() or {}
+        required = ["title", "educator_id", "school_id"]
+
+        # Basic validation
+        for field in required:
+            if not str(data.get(field, "")).strip():
+                return {"message": f"{field} is required"}, 400
+
+        title = data["title"].strip()
+        description = data.get("description", "").strip()
+        educator_id = data["educator_id"]
+        school_id = data["school_id"]
+
+        # Prevent duplicate titles in the same school
+        if Course.query.filter_by(title=title, school_id=school_id).first():
+            return {
+                "message": f"A course with the title '{title}' already exists in this school."
+            }, 400
+
+        try:
+            new_course = Course(
+                title=title,
+                description=description,
+                educator_id=educator_id,
+                school_id=school_id,
+            )
+            db.session.add(new_course)
+            db.session.commit()
+            return {
+                "message": "Course created successfully.",
+                "course": new_course.to_dict(),
+            }, 201
+        except Exception as e:
+            db.session.rollback()
+            return {"message": "Error creating course.", "error": str(e)}, 500
+
+
+class CourseResource(Resource):
+    def get(self, course_id):
+        """
+        GET /courses/<id>
+        Fetch a single course by ID.
+        """
+        course = Course.query.get_or_404(course_id)
+        return course.to_dict(), 200
+
+    def put(self, course_id):
+        """
+        PUT /courses/<id>
+        Update a course.
+        Fields allowed: title, description, educator_id
+        """
+        course = Course.query.get_or_404(course_id)
+        data = request.get_json() or {}
+
+        # Handle title update with duplicate check
+        if "title" in data and data["title"].strip():
+            new_title = data["title"].strip()
+            if Course.query.filter(
+                Course.title == new_title,
+                Course.school_id == course.school_id,
+                Course.id != course_id,
+            ).first():
+                return {
+                    "message": f"Another course with the title '{new_title}' already exists in this school."
+                }, 400
+            course.title = new_title
+
+        # Update optional fields
+        if "description" in data:
+            course.description = data["description"].strip()
+
+        if "educator_id" in data:
+            course.educator_id = data["educator_id"]
+
+        try:
+            db.session.commit()
+            return {
+                "message": "Course updated successfully.",
+                "course": course.to_dict(),
+            }, 200
+        except Exception as e:
+            db.session.rollback()
+            return {"message": "Error updating course.", "error": str(e)}, 500
+
+    def delete(self, course_id):
+        """
+        DELETE /courses/<id>
+        Permanently remove a course.
+        """
+        course = Course.query.get_or_404(course_id)
+        try:
+            db.session.delete(course)
+            db.session.commit()
+            return {"message": f"Course '{course.title}' deleted successfully."}, 200
+        except Exception as e:
+            db.session.rollback()
+            return {"message": "Error deleting course.", "error": str(e)}, 500


### PR DESCRIPTION
**Summary**
This PR introduces the Course API routes, providing full RESTful support for course management. It also implements production-ready pagination and basic filtering/search for a more scalable API design.
**Changes Made**
- Added app/routes/course.py with:
- CourseListResource → supports GET /courses (paginated & filterable) and POST /courses (create).
- CourseResource → supports GET /courses/<id>, PUT /courses/<id>, and DELETE /courses/<id>.
- Pagination utility integrated into all list endpoints.
- Filtering by school_id and optional text search (search query param).
- Prevent duplicate course titles within the same school.
- Added error handling with rollback on DB errors.
- Responses use .to_dict() (via SerializerMixin) for consistent JSON output.
 **How to Test**
Run migrations and seed data if not already done:
```
flask db upgrade
flask seed
```
Start the server:
`flask run`
**Test endpoints:**
- GET /api/courses?page=1&per_page=5 → should return paginated courses.
- GET /api/courses?school_id=1&search=Math → should filter results.
- POST /api/courses with JSON body → creates a new course.
- PUT /api/courses/<id> → updates course.
- DELETE /api/courses/<id> → deletes the course.
**Notes**
Future improvement: extend filtering to include educator and date ranges.