### PR TITLE
CRITICAL FIX: Ensure redirect files are copied to dist + fix Vite con…

### DIFF
--- a/client/public/render.toml
+++ b/client/public/render.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/client/public/render.yaml
+++ b/client/public/render.yaml
@@ -1,4 +1,0 @@
-routes:
-  - type: rewrite
-    source: /*
-    destination: /index.html

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -5,9 +5,16 @@ import path from 'path'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  base: '/',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),
     },
+  },
+  // Ensure all public files are copied to dist
+  publicDir: 'public',
+  build: {
+    copyPublicDir: true,
+    outDir: 'dist',
   },
 })


### PR DESCRIPTION
…fig for SPA routing

- Add explicit publicDir and copyPublicDir to vite.config.js
- Replace render.yaml with render.toml (better Render support)
- Add base: '/' for proper asset paths
- Now _redirects and render.toml are properly copied to dist/